### PR TITLE
fixed recent not actually including all recent touched tickets

### DIFF
--- a/src/controllers/tickets/recent_tickets.php
+++ b/src/controllers/tickets/recent_tickets.php
@@ -14,13 +14,16 @@ if ($_SESSION['permissions']['is_admin'] != 1) {
 require_once('helpdbconnect.php');
 include("ticket_utils.php");
 
-//page query
-$ticket_query = "(SELECT * FROM tickets WHERE employee = '" . $_SESSION['username'] . "')
-UNION
-(SELECT tickets.* FROM tickets 
-JOIN notes ON tickets.id = notes.linked_id 
-WHERE notes.creator = '" . $_SESSION['username'] . "')
-ORDER BY last_updated DESC";
+$username = $_SESSION['username'];
+
+$ticket_query = <<<QUERY
+SELECT DISTINCT tickets.* FROM tickets 
+LEFT JOIN notes ON tickets.id = notes.linked_id 
+LEFT JOIN ticket_logs ON tickets.id = ticket_logs.ticket_id
+WHERE notes.creator = '$username' OR ticket_logs.user_id = '$username'
+ORDER BY tickets.last_updated DESC
+QUERY;
+
 
 $ticket_result = mysqli_query($database, $ticket_query);
 


### PR DESCRIPTION
I'm getting alot of 

 help-web      | [Sat Feb 10 03:26:55.416863 2024] [php:warn] [pid 25] [client 192.168.65.1:38732] PHP Warning:  Undefined array key 0 in /var/www/html/includes/functions.php on line 85, referer: http://localhost:8080/tickets.php
 
 errors while this runs now, but I believe that's because of the peterb user in my local stack.
 
 its referencing the new client name lookup function.