### PR TITLE
updated Session handling and inactivity modal

### DIFF
--- a/src/google_login.php
+++ b/src/google_login.php
@@ -83,6 +83,8 @@ if (isset($_GET['code'])) {
         $update_stmt = $database->prepare("UPDATE users SET last_login = NOW(), gsso = ?, ldap_location = ? WHERE email = ?");
         $update_stmt->bind_param("sis", $user_ucode, $loc, $email);
         $update_stmt->execute();
+        // Store the last login time in the session
+        $_SESSION['last_login'] = date("Y-m-d H:i:s");
         if ($update_stmt === false) {
             $error_message = 'Prepare failed: (' . $database->errno . ') ' . $database->error;
             error_log($error_message, 0);

--- a/src/includes/footer.php
+++ b/src/includes/footer.php
@@ -5,7 +5,14 @@
 <div id="timeoutModal" style="display: none; position: fixed; z-index: 1; left: 0; top: 0; width: 100%; height: 100%; overflow: auto; background-color: rgba(0,0,0,0.4);">
     <div style="background-color: #fefefe; margin: 15% auto; padding: 20px; border: 1px solid #888; width: 80%;">
         <h2>Inactivity Alert</h2>
-        <p>Your session will expire soon due to inactivity.</p>
+        <p>You've been innactive for more than 30 minutes.</p>
+        <?php
+        // Check if the user has been logged in for more than 2 hours and display the appropriate message about session likely broken
+        if ($time_difference > 2 * 60 * 60) {
+            echo "<p>Your session may have expired. It's recommended to log out and back in.</p>";
+            log_app(LOG_INFO, $_SESSION['username'] . " alerted of old session");
+        }
+        ?>
         <button onclick="dismiss_timeout_modal()">Dismiss</button>
         <button onclick="location.reload()">Reload Page</button>
     </div>

--- a/src/includes/init.php
+++ b/src/includes/init.php
@@ -19,10 +19,10 @@ if (isset($_SESSION['last_timestamp'])) {
     $time_difference = $current_time - strtotime($user_last_login);
 
     // Check if the user has been logged in for more than 2 hours
-    if ($time_difference > 60 * 60 * 2) {
+    if ($time_difference > 60 * 60 * 3) {
         // Unset all session variables
         $_SESSION = array();
-        log_app(LOG_INFO, $_SESSION['username'] . " Session killed for being older than 2 hours");
+        log_app(LOG_INFO, $_SESSION['username'] . " Session killed for being older than 3 hours");
         // Delete the session cookie
         session_unset();
         // Destroy the session

--- a/src/includes/init.php
+++ b/src/includes/init.php
@@ -18,11 +18,11 @@ if (isset($_SESSION['last_timestamp'])) {
     // Calculate the time difference in seconds
     $time_difference = $current_time - strtotime($user_last_login);
 
-
-    if ($time_since_last_login > 4 * 60 * 60) {
+    // Check if the user has been logged in for more than 2 hours
+    if ($time_difference > 60 * 60 * 2) {
         // Unset all session variables
         $_SESSION = array();
-        log_app(LOG_INFO, $_SESSION['username'] . " Session killed for being older than 4 hours");
+        log_app(LOG_INFO, $_SESSION['username'] . " Session killed for being older than 2 hours");
         // Delete the session cookie
         session_unset();
         // Destroy the session

--- a/src/includes/js/main.js
+++ b/src/includes/js/main.js
@@ -248,20 +248,37 @@ if (updateTicketForm) {
 }
 
 //================================= Inactive User Modal =================================
+var timeoutId; // Declare timeoutId at the top level so it can be accessed from both functions
+
 function setupInactivityModal() {
   var inactivityTime = 30 * 60 * 1000; // 30 minutes in milliseconds
   var timeoutModal = document.getElementById("timeoutModal");
+  var iframe = document.getElementById("note_ifr"); // Replace with your iframe's id
 
-  var timeoutId = setTimeout(showTimeoutModal, inactivityTime);
+  timeoutId = setTimeout(showTimeoutModal, inactivityTime);
 
   function showTimeoutModal() {
     timeoutModal.style.display = "block";
   }
+
+  function resetTimeout() {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(showTimeoutModal, inactivityTime);
+  }
+
+  window.addEventListener("click", resetTimeout);
+  window.addEventListener("keydown", resetTimeout);
+
+  // Add same event listeners to the document inside the iframe
+  iframe.contentWindow.document.addEventListener("click", resetTimeout);
+  iframe.contentWindow.document.addEventListener("keydown", resetTimeout);
 }
 
 function dismiss_timeout_modal() {
   const timeoutModal = document.getElementById("timeoutModal");
   timeoutModal.style.display = "none";
+  clearTimeout(timeoutId); // Clear the existing timeout
+  timeoutId = setTimeout(showTimeoutModal, 30 * 60 * 1000); // Start a new timeout
 }
 
 // Call the function when the page loads


### PR DESCRIPTION
added event listeners so if typing or clicking it resets inactivity timer


We've updated session handling: each time the page loads, it checks the last login time. If the user has been logged in for more than 3 hours, the session is destroyed and the user is logged out.

Additionally, the inactivity alert has been adjusted. After 2 hours since the last login, a message will appear explaining the session duration and suggesting a re-login.

will continue to tune this behavior as needed

 
changes on stage and will be included in the next release