### PR TITLE
fix script permissions

### DIFF
--- a/php.Dockerfile
+++ b/php.Dockerfile
@@ -85,4 +85,4 @@ RUN mkdir -p /var/www/html/twig-cache && chown -R www-data:www-data /var/www/htm
 
 RUN chown -R www-data:www-data /var/www/html/
 
-CMD service cron start && chown -R www-data:www-data /var/www/html/vendor && chmod -R 550 /var/www/html/scripts && chown -R www-data:www-data /var/php/sessions && composer install --no-interaction --no-ansi --no-scripts --no-progress --prefer-dist && docker-php-entrypoint apache2-foreground
+CMD service cron start && chown -R www-data:www-data /var/www/html/vendor && chmod -R 655 /var/www/html/scripts && chown -R www-data:www-data /var/php/sessions && composer install --no-interaction --no-ansi --no-scripts --no-progress --prefer-dist && docker-php-entrypoint apache2-foreground


### PR DESCRIPTION
this stops git from not being able to read the files properly.

git would then start complaining about un synced changes because the file permissions.