### PR TITLE
use app version variable to purge included js

### DIFF
--- a/src/public/controllers/tickets/edit_ticket.php
+++ b/src/public/controllers/tickets/edit_ticket.php
@@ -1374,8 +1374,8 @@ const MAX_VISIBLE_NOTE_COUNT = 10;
         setInterval(updateTimeSinceLastNote, 60000); // 60000 milliseconds
     </script>
 <?php endif; ?>
-<script src="/includes/js/note_submit.js?v=?v=1.0.05" type="text/javascript"></script>
-<script src="/includes/js/pages/edit_ticket.js?v=1.0.06" type="text/javascript"></script>
+<script src="/includes/js/note_submit.js?v=<?= $app_version ?>" type="text/javascript"></script>
+<script src="/includes/js/pages/edit_ticket.js?v=<?= $app_version ?>" type="text/javascript"></script>
 <?php include("footer.php"); ?>
 
 


### PR DESCRIPTION
this was just an issue on edit_ticket.php. since this page hasn't been put into twig. the few js files that are included on this page didn't have proper version numbers