### PR TITLE
restore row coloring and prep for new user settings table

### DIFF
--- a/src/php-includes/boot.php
+++ b/src/php-includes/boot.php
@@ -1,6 +1,6 @@
 <?php
 
-$app_version = "1.4.05";
+$app_version = "1.4.6";
 
 function from_root(string $path)
 {

--- a/src/php-includes/ticket_utils.php
+++ b/src/php-includes/ticket_utils.php
@@ -868,3 +868,23 @@ function get_parent_ticket_for_ticket(int $ticket_id)
     $row = $res->fetch_assoc();
     return $row["parent_ticket"];
 }
+
+function get_user_setting($userId, $settingName)
+{
+    try {
+        // query to get the setting value
+        $result = HelpDB::get()->execute_query("SELECT $settingName FROM user_settings WHERE user_id = ?", [$userId]);
+
+        // Fetch the setting value if it exists
+        if ($result && $row = $result->fetch_assoc()) {
+            return $row[$settingName];
+        }
+
+        // Return null if the setting is not found
+        return null;
+    } catch (Exception $e) {
+        // if setting is not found, log the error and return null
+        log_app(LOG_ERR, "Failed to get user setting: $settingName for user: $userId");
+        return null;
+    }
+}

--- a/src/public/new-controllers/base_variables.php
+++ b/src/public/new-controllers/base_variables.php
@@ -5,7 +5,7 @@ if (!session_id()) {
     session_start();
 }
 //included in twig base_variables and in functions.php while transitioning to twig
-$app_version = "1.4.05";
+$app_version = "1.4.6";
 
 // check if logged in. redirects to login page if not
 if (!$_SESSION['username']) {

--- a/src/public/tickets.php
+++ b/src/public/tickets.php
@@ -11,8 +11,8 @@ if (session_is_intern()) {
 require from_root("/../vendor/autoload.php");
 require from_root("/new-controllers/ticket_base_variables.php");
 
-
-
+// get user setting for if to show alerts or not
+$show_alerts = get_user_setting(get_id_for_user($_SESSION['username']), 'show_alerts');
 
 $loader = new \Twig\Loader\FilesystemLoader(from_root('/../views'));
 $twig = new \Twig\Environment($loader, [
@@ -50,7 +50,6 @@ $client_tickets = get_parsed_ticket_data($client_ticket_result);
 
 $alert_result = HelpDB::get()->execute_query("SELECT * FROM alerts WHERE employee = ? AND supervisor_alert = 0", [$username]);
 $alerts = get_parsed_alert_data($alert_result);
-
 echo $twig->render('tickets.twig', [
     // base variables
     'color_scheme' => $color_scheme,
@@ -75,5 +74,7 @@ echo $twig->render('tickets.twig', [
     'my_tickets' => $my_tickets,
     'open_tickets' => $client_tickets,
     'alerts' => $alerts,
+    'hide_alerts' => $_SESSION['hide_alerts'],
+    // 'show_alerts' => $show_alerts
     'show_alerts' => 1
 ]);

--- a/src/public/tickets.php
+++ b/src/public/tickets.php
@@ -75,5 +75,5 @@ echo $twig->render('tickets.twig', [
     'my_tickets' => $my_tickets,
     'open_tickets' => $client_tickets,
     'alerts' => $alerts,
-    'hide_alerts' => $_SESSION['hide_alerts']
+    'show_alerts' => 1
 ]);

--- a/src/views/tickets_table.twig
+++ b/src/views/tickets_table.twig
@@ -19,7 +19,17 @@
     </thead>
     <tbody>
         {% for ticket in tickets %}
-        <tr>
+        {% if show_alerts %}
+                {% if ticket.yellow_alert_enabled and not ticket.red_alert_enabled %}
+                    <tr class="warn">
+                {% elseif ticket.red_alert_enabled %}
+                    <tr class="crit">
+                {% else %}
+                    <tr>
+                {% endif %}
+            {% else %}
+                <tr>
+            {% endif %}
             <td data-cell="ID"><a href="/controllers/tickets/edit_ticket.php?id={{ ticket.id }}">{{ ticket.id }}</a></td>
             <td data-cell="Alerts" width="50px">
                 <div>


### PR DESCRIPTION
make new table
```mysql
CREATE TABLE help.user_settings (
    user_id INT PRIMARY KEY,
    show_alerts TINYINT(1) NOT NULL DEFAULT 1,
    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
);
```
propagate table with first setting
```mysql
INSERT INTO user_settings (user_id, show_alerts)
SELECT id, 1
FROM users
ON DUPLICATE KEY UPDATE show_alerts = VALUES(show_alerts);
```


Hardcoded the show_alerts value to true to restore the feature while the user settings page is being built and settings are migrated to the new table.
Initially considered fetching the value from the new table which does work fine, but updating settings across two tables felt overly complex.
next step will be to migrate all settings to the new table and rebuild the settings page afterward.