### PR TITLE
interns were landing on tickets.php instead of intern_tickets.php

### DIFF
--- a/src/views/ticket_base.twig
+++ b/src/views/ticket_base.twig
@@ -21,7 +21,7 @@
         <li><a href="/controllers/tickets/search_tickets.php">Search Tickets</a></li>
     {% else %}
         {% if user_permissions.is_intern %}
-            <li><a href="/tickets.php">Intern Tickets ({{ num_assigned_intern_tickets }})</a></li>
+            <li><a href="/controllers/tickets/intern_tickets.php">Intern Tickets ({{ num_assigned_intern_tickets }})</a></li>
         {% else %}
             <li><a href="/tickets.php">My Tickets</a></li>
         {% endif %}


### PR DESCRIPTION
this was a strange one.

Evan called to report this issue where his interns could not see the intern tickets.

fixing this link on the template fixed the problem, but that line hasn't changed in 4months is what the history was saying.

according to Evan and intern it was working find just last week.